### PR TITLE
Add multi_region.

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,14 +101,14 @@ data "aws_iam_policy_document" "s3_kms_policy" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.26 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=1.5.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.26 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.0 |
 
 ## Modules
 
@@ -127,7 +127,8 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_key_description"></a> [key\_description](#input\_key\_description) | The description given to the created CMK | `string` | `""` | no |
 | <a name="input_key_policy"></a> [key\_policy](#input\_key\_policy) | IAM key policy for the kms key | `any` | `null` | no |
-| <a name="input_kms_key_resource_type"></a> [kms\_key\_resource\_type](#input\_kms\_key\_resource\_type) | the type of resource/service this key is for, such as S3, EBS or RDS | `string` | n/a | yes |
+| <a name="input_kms_key_resource_type"></a> [kms\_key\_resource\_type](#input\_kms\_key\_resource\_type) | The type of resource/service this key is for, such as S3, EBS or RDS | `string` | n/a | yes |
+| <a name="input_multi_region"></a> [multi\_region](#input\_multi\_region) | Indicates whether the KMS key is a multi-Region (true) or regional (false) key. | `bool` | `false` | no |
 | <a name="input_resource_prefix"></a> [resource\_prefix](#input\_resource\_prefix) | The prefix of the KMS key alias | `string` | n/a | yes |
 
 ## Outputs

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,7 @@
 resource "aws_kms_key" "kms_key" {
   description         = local.cmk_description
   policy              = var.key_policy
+  multi_region        = var.multi_region
   enable_key_rotation = true
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -18,3 +18,9 @@ variable "key_description" {
   type        = string
   default     = ""
 }
+
+variable "multi_region" {
+  description = "Indicates whether the KMS key is a multi-Region (true) or regional (false) key."
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
This change adds and exposes the "multi_region" argument of the aws_kms_key resource, but leaves it at its default value of "false".

Specific use-case:
Someone may want to use another AWS Region as a Disaster Recovery environment but may not want the overhead of managing additional KMS keys, which are regional by default.